### PR TITLE
Extend swagger2.0 HTTP status code regex

### DIFF
--- a/specio/resources/schemas/v2.0/schema.json
+++ b/specio/resources/schemas/v2.0/schema.json
@@ -331,7 +331,7 @@
       "minProperties": 1,
       "additionalProperties": false,
       "patternProperties": {
-        "^([0-9]{3})$|^(default)$": {
+        "^([1-5](?:\\d{2}|XX))$|^(?:default)$": {
           "$ref": "#/definitions/responseValue"
         },
         "^x-": {


### PR DESCRIPTION
- Swagger 2.0 supports status codes `2XX`, `3XX`, etc
- use non-matching groups
- disallow status codes where first digit = 0/6/7/8/9